### PR TITLE
Fix reader literal usage

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,6 @@
 (defproject wormbase/pseudoace "0.3.2-SNAPSHOT"
-  :dependencies [[com.amazonaws/aws-java-sdk-dynamodb "1.9.39"
+  :dependencies [[clj-time "0.11.0"]
+                 [com.amazonaws/aws-java-sdk-dynamodb "1.9.39"
                   :exclusions [joda-time]]
                  [com.datomic/datomic-pro "0.9.5350"
                   :exclusions [joda-time]]

--- a/src/pseudoace/acedump.clj
+++ b/src/pseudoace/acedump.clj
@@ -1,9 +1,9 @@
-(ns wb.acedump
-  (:use pseudoace.utils)
-  (:require [datomic.api :as d :refer (q datoms entity)]
+(ns pseudoace.acedump
+  (:require [datomic.api :as d]
             [clojure.string :as str]
             [clj-time.coerce :as tc]
-            [clj-time.format :as tf]))
+            [clj-time.format :as tf]
+            [pseudoace.utils :refer (throw-exc)]))
 
 (defrecord Node [type ts value children])
 

--- a/src/pseudoace/acedump.clj
+++ b/src/pseudoace/acedump.clj
@@ -73,10 +73,10 @@
     :db.type/string
       (Node. :text     ts (:v datom) nil)
     :db.type/ref
-      (let [e (entity db (:v datom))]
+      (let [e (d/entity db (:v datom))]
         (or
          (if-let [obj-ref (:pace/obj-ref attr)]
-           (Node. (:pace/identifies-class (entity db obj-ref))
+           (Node. (:pace/identifies-class (d/entity db obj-ref))
                   ts
                   (obj-ref e)
                   nil))
@@ -84,9 +84,14 @@
          (if-let [tags (:pace/tags e)]
            (Node. :tag ts tags nil))
 
-         (ace-object db (:v datom) (into #{(str (namespace (:db/ident attr)) "." (name (:db/ident attr)))}
-                                         (:pace/use-ns attr)))))
-
+         (ace-object
+          db
+          (:v datom)
+          (into #{(str
+                   (namespace (:db/ident attr))
+                   "."
+                   (name (:db/ident attr)))}
+                (:pace/use-ns attr)))))
     ;; default
     (Node. :text ts "Unknown!" nil)))
 
@@ -99,9 +104,9 @@
   ([db ent a v obj-ref]
    (or
     (if-let [r (obj-ref ent)]
-      [r (entity db a) v])
+      [r (d/entity db a) v])
     (if-let [[e a v t] (first (d/datoms db :vaet (:db/id ent)))]
-      (xref-obj db (entity db e) a v obj-ref)))))
+      (xref-obj db (d/entity db e) a v obj-ref)))))
      
 (defn ace-object
  ([db eid]
@@ -111,7 +116,7 @@
         data          (->>
                        (partition-by :a datoms)
                        (map (fn [d]
-                              [(entity db (:a (first d))) d])))
+                              [(d/entity db (:a (first d))) d])))
         data          (if restrict-ns
                         (filter (fn [[a v]]
                                   (restrict-ns (namespace (:db/ident a))))
@@ -120,7 +125,7 @@
         tsmap         (->> (map :tx datoms)
                            (set)
                            (map (fn [tx]
-                                  [tx (tx->ts (entity db tx))]))
+                                  [tx (tx->ts (d/entity db tx))]))
                            (into {}))
 
         ;; Split positional from tagged attributes
@@ -165,11 +170,11 @@
                         (fn [root xref]
                           (if-let [datoms (seq (d/datoms db :vaet eid (:pace.xref/attribute xref)))]
                             (let [obj-ref (:pace.xref/obj-ref xref)
-                                  xclass  (:pace/identifies-class (entity db obj-ref))
+                                  xclass  (:pace/identifies-class (d/entity db obj-ref))
                                   tsmap   (->> (map :tx datoms)
                                                (set)
                                                (map (fn [tx]
-                                                      [tx (tx->ts (entity db tx))]))
+                                                      [tx (tx->ts (d/entity db tx))]))
                                                (into {}))
                                   min-ts  (->> (map (comp tsmap :tx) datoms)
                                                (reduce smin))]
@@ -179,7 +184,7 @@
                                min-ts
                                (mapcat
                                 (fn [datom]
-                                  (let [e          (entity db (:e datom))
+                                  (let [e          (d/entity db (:e datom))
                                         [o a comp] (xref-obj db e obj-ref)
                                         children   (if (and a comp)
                                                      (if-let [hash-ns (:pace.xref/use-ns xref)]
@@ -260,15 +265,16 @@
 (defn dump-class
   "Dump object of class `class` from `db`."
   [db class & {:keys [query delete tag follow format limit]}]
-  (if-let [ident (q '[:find ?class-ident .
-                     :in $ ?class
-                     :where [?attr :pace/identifies-class ?class]
-                            [?attr :db/ident ?class-ident]]
+  (if-let [ident (d/q '[:find ?class-ident .
+                        :in $ ?class
+                        :where
+                        [?attr :pace/identifies-class ?class]
+                        [?attr :db/ident ?class-ident]]
                    db class)]
-    (doseq [id (->> (q '[:find [?id ...]
-                         :in $ ?ident
-                         :where [?id ?ident _]]
-                       db ident)
+    (doseq [id (->> (d/q '[:find [?id ...]
+                           :in $ ?ident
+                           :where [?id ?ident _]]
+                         db ident)
                     (sort)
                     (take (or limit Integer/MAX_VALUE)))]
       (dump-object (ace-object db id)))

--- a/src/pseudoace/core.clj
+++ b/src/pseudoace/core.clj
@@ -366,7 +366,7 @@
   (let [con (d/connect url)]
     (d/transact
      con
-     [{:db/id #db/id[:db.part/user] :db/excise :importer/temp}])))
+     [{:db/id (d/tempid :db.part/user) :db/excise :importer/temp}])))
 
 (defn run-test-query
   "Perform tests on the generated database."
@@ -415,13 +415,13 @@
                    (java.util.zip.GZIPInputStream.)
                    (ace/ace-reader)
                    (ace/ace-seq)
-                   (partition-all 20))] ;; Larger block size may be faster if
-    ;; you have plenty of memory.
+                   (partition-all 20))] ; Larger block size may be faster if
+                                        ; you have plenty of memory.
     (loc-import/split-locatables-to-dir helper-db blk log-dir)))
 
 (defn run-locatables-importer-for-helper
-  ([url]
-   (run-locatables-importer-for-helper url false))
+  ([url acedump-dir]
+   (run-locatables-importer-for-helper url acedump-dir :verbose false))
   ([url log-dir acedump-dir verbose]
    (if verbose
      (println "Importing logs with loactables importer into helper database"))

--- a/src/pseudoace/feature_loader.clj
+++ b/src/pseudoace/feature_loader.clj
@@ -1,14 +1,15 @@
 (ns pseudoace.feature-loader
-  (use pseudoace.utils
-       clojure.instant
-       clojure.java.io)
-  (require [datomic.api :as d :refer (db q entity touch tempid)]
-           [clojure.string :as str]
-           [clojure.edn :as edn]
-           [pseudoace.aceparser :as ace])
-  (import java.io.FileInputStream
-          java.io.PushbackReader
-          java.util.zip.GZIPInputStream))
+  (:require
+   [clojure.edn :as edn]
+   [clojure.instant :refer (read-instant-date)]
+   [clojure.java.io :as io]
+   [clojure.string :as str]
+   [datomic.api :as d :refer (db q entity touch tempid)]
+   [pseudoace.aceparser :as ace]
+   [pseudoace.utils :refer (parse-double parse-int vmap)])
+  (:import java.io.FileInputStream
+           java.io.PushbackReader
+           java.util.zip.GZIPInputStream))
 
 (defrecord FeatureLink [sequence start end])
 
@@ -154,7 +155,7 @@
   []) 
 
 (defn load-feature-map [f]
-  (with-open [r (PushbackReader. (reader f))]
+  (with-open [r (PushbackReader. (io/reader f))]
     (->> (edn/read r)
          (map (fn [[seq fid start end]]
                 [fid (FeatureLink. seq start end)]))

--- a/src/pseudoace/locatable_schema.clj
+++ b/src/pseudoace/locatable_schema.clj
@@ -1,5 +1,8 @@
 (ns pseudoace.locatable-schema
-  (:use datomic-schema.schema))
+  (:require [datomic.api :refer (tempid)]
+            [datomic-schema.schema :refer (fields
+                                           generate-schema
+                                           schema)]))
 
 (def locatable-schema
  (concat
@@ -143,7 +146,7 @@
 
    ])
 
-  [{:db/id          #db/id[:db.part/tx]
+  [{:db/id          (tempid :db.part/tx)
     :db/txInstant   #inst "1970-01-01T00:00:01"}]))
 
 ;;
@@ -152,7 +155,7 @@
 ;;
 (def locatable-extras
  (concat
-  [{:db/id          #db/id[:db.part/db]
+  [{:db/id          (tempid :db.part/db)
     :db/ident       :locatable/parent
 
     ;; this isn't always true, but needed for current Colonnade code.
@@ -160,43 +163,43 @@
 
     :pace/tags      "Parent"}
    
-   {:db/id          #db/id[:db.part/db]
+   {:db/id          (tempid :db.part/db)
     :db/ident       :locatable/min
     :pace/tags      "Position Min"}
 
-   {:db/id          #db/id[:db.part/db]
+   {:db/id          (tempid :db.part/db)
     :db/ident       :locatable/max
     :pace/tags      "Position Max"}
 
-   {:db/id          #db/id[:db.part/db]
+   {:db/id          (tempid :db.part/db)
     :db/ident       :locatable/method
     :pace/obj-ref   :method/id
     :pace/tags      "Method"}
 
-   {:db/id          #db/id[:db.part/db]
+   {:db/id          (tempid :db.part/db)
     :db/ident       :locatable/score
     :pace/tags      "Score"}
    
-   {:db/id          #db/id[:db.part/db]
+   {:db/id          (tempid :db.part/db)
     :db/ident       :locatable/strand
     :pace/tags      "Strand"}
    
-   {:db/id          #db/id[:db.part/user]
+   {:db/id          (tempid :db.part/user)
     :db/ident       :locatable.strand/positive
     :pace/tags      "Positive"}
 
-   {:db/id          #db/id[:db.part/user]
+   {:db/id          (tempid :db.part/user)
     :db/ident       :locatable.strand/negative
     :pace/tags      "Negative"}
 
-   {:db/id          #db/id[:db.part/user]
+   {:db/id          (tempid :db.part/user)
     :db/ident       :homology.strand/positive
     :pace/tags      "Positive"}
 
-   {:db/id          #db/id[:db.part/user]
+   {:db/id          (tempid :db.part/user)
     :db/ident       :homology.strand/negative
     :pace/tags      "Negative"}]
   
-  [{:db/id          #db/id[:db.part/tx]
+  [{:db/id          (tempid :db.part/tx)
     :db/txInstant   #inst "1970-01-01T00:00:01"}]))
 

--- a/src/pseudoace/metadata_schema.clj
+++ b/src/pseudoace/metadata_schema.clj
@@ -1,5 +1,4 @@
 (ns pseudoace.metadata-schema
-  (:use datomic-schema.schema)
   (:require [datomic.api :refer (tempid)]))
 
 (def metaschema
@@ -136,7 +135,7 @@
     :db.install/_attribute :db.part/db
     :pace/identifies-class "LongText"}
 
-   {:db/id           #db/id[:db.part/db]
+   {:db/id           (tempid :db.part/db)
     :db/ident        :longtext/text
     :db/cardinality  :db.cardinality/one
     :db/valueType    :db.type/string
@@ -153,7 +152,7 @@
     :db.install/_attribute :db.part/db
     :pace/identifies-class "DNA"}
 
-   {:db/id           #db/id[:db.part/db]
+   {:db/id           (tempid :db.part/db)
     :db/ident        :dna/sequence
     :db/cardinality  :db.cardinality/one
     :db/valueType    :db.type/string
@@ -169,7 +168,7 @@
     :db.install/_attribute :db.part/db
     :pace/identifies-class "Peptide"}
 
-   {:db/id           #db/id[:db.part/db]
+   {:db/id           (tempid :db.part/db)
     :db/ident        :peptide/sequence
     :db/cardinality  :db.cardinality/one
     :db/valueType    :db.type/string
@@ -270,6 +269,4 @@
     :db.install/_attribute :db.part/db}
 
    {:db/id            (tempid :db.part/tx)
-    :db/txInstant     #inst "1970-01-01T00:00:01"}
-
-   ])
+    :db/txInstant     #inst "1970-01-01T00:00:01"}])

--- a/src/pseudoace/pace.clj
+++ b/src/pseudoace/pace.clj
@@ -66,7 +66,7 @@
   [db ent]
   (let [schemas        (map #(touch (entity db %)) (keys ent))
         right-schemas  (filter is-hash? schemas)
-        left-schemas   (filter (complement is-hash?) schemas)]
+        left-schemas   (remove is-hash? schemas)]
     (objectify-level db ent left-schemas (when right-schemas
                                       (objectify-level db ent right-schemas nil)))))
 
@@ -237,12 +237,13 @@
                        (str (:value n))
                        "")
                   [fs & rs] (wrap-lines ns target-width)]
-              (conj! tab-stops actual-ts)
-              (print (apply str (repeat (- actual-ts column) \space)))
+              (let [_ (conj! tab-stops actual-ts)]
+                nil)
+              (print (str/join (repeat (- actual-ts column))))
               (print fs)
               (doseq [rl rs]
                 (println)
-                (print (apply str (repeat (+ actual-ts 2) \space)))
+                (print (str/join (repeat (+ actual-ts 2))))
                 (print rl))
               (recur (+ actual-ts (max (count fs)
                                        (reduce 

--- a/src/pseudoace/schemata.clj
+++ b/src/pseudoace/schemata.clj
@@ -377,7 +377,7 @@
 (def locatable-extras
   "Add locatable XREFs to the pace schema."
   (concat
-   [{:db/id          #db/id[:db.part/db]
+   [{:db/id          (tempid :db.part/db)
      :db/ident       :locatable/parent
 
      ;; this isn't always true, but needed for current Colonnade code.
@@ -385,40 +385,40 @@
 
      :pace/tags      "Parent"}
     
-    {:db/id          #db/id[:db.part/db]
+    {:db/id          (tempid :db.part/db)
      :db/ident       :locatable/min
      :pace/tags      "Position Min"}
 
-    {:db/id          #db/id[:db.part/db]
+    {:db/id          (tempid :db.part/db)
      :db/ident       :locatable/max
      :pace/tags      "Position Max"}
 
-    {:db/id          #db/id[:db.part/db]
+    {:db/id          (tempid :db.part/db)
      :db/ident       :locatable/method
      :pace/obj-ref   :method/id
      :pace/tags      "Method"}
 
-    {:db/id          #db/id[:db.part/db]
+    {:db/id          (tempid :db.part/db)
      :db/ident       :locatable/score
      :pace/tags      "Score"}
     
-    {:db/id          #db/id[:db.part/db]
+    {:db/id          (tempid :db.part/db)
      :db/ident       :locatable/strand
      :pace/tags      "Strand"}
     
-    {:db/id          #db/id[:db.part/user]
+    {:db/id          (tempid :db.part/user)
      :db/ident       :locatable.strand/positive
      :pace/tags      "Positive"}
 
-    {:db/id          #db/id[:db.part/user]
+    {:db/id          (tempid :db.part/user)
      :db/ident       :locatable.strand/negative
      :pace/tags      "Negative"}
 
-    {:db/id          #db/id[:db.part/user]
+    {:db/id          (tempid :db.part/user)
      :db/ident       :homology.strand/positive
      :pace/tags      "Positive"}
 
-    {:db/id          #db/id[:db.part/user]
+    {:db/id          (tempid :db.part/user)
      :db/ident       :homology.strand/negative
      :pace/tags      "Negative"}]))
 
@@ -461,39 +461,39 @@
 ;; https://github.com/WormBase/db/wiki/Ace-to-Datomic-mapping#xrefs-in-hash-models
 (def xref-fixups
   "XREFs inside hash models"
-  [{:db/id               #db/id[:db.part/user]
+  [{:db/id               (tempid :db.part/user)
     :pace.xref/attribute :multi-counts.gene/gene
     :pace.xref/obj-ref   :multi-pt-data/id}
 
-   {:db/id               #db/id[:db.part/user]
+   {:db/id               (tempid :db.part/user)
     :pace.xref/attribute :multi-counts.allele/variation
     :pace.xref/obj-ref   :multi-pt-data/id}
 
-   {:db/id               #db/id[:db.part/user]
+   {:db/id               (tempid :db.part/user)
     :pace.xref/attribute :multi-counts.locus/locus
     :pace.xref/obj-ref   :multi-pt-data/id}
 
-   {:db/id               #db/id[:db.part/user]
+   {:db/id               (tempid :db.part/user)
     :pace.xref/attribute :multi-counts.transgene/transgene
     :pace.xref/obj-ref   :multi-pt-data/id}
 
-   {:db/id               #db/id[:db.part/user]
+   {:db/id               (tempid :db.part/user)
     :pace.xref/attribute :multi-counts.rearrangement/rearrangement
     :pace.xref/obj-ref   :multi-pt-data/id}
 
-   {:db/id               #db/id[:db.part/user]
+   {:db/id               (tempid :db.part/user)
     :pace.xref/attribute :mass-spec-data/protein
     :pace.xref/obj-ref   :mass-spec-peptide/id}
 
-   {:db/id               #db/id[:db.part/user]
+   {:db/id               (tempid :db.part/user)
     :pace.xref/attribute :interactor-info/transgene
     :pace.xref/obj-ref   :interaction/id}
 
-   {:db/id               #db/id[:db.part/user]
+   {:db/id               (tempid :db.part/user)
     :pace.xref/attribute :interactor-info/construct
     :pace.xref/obj-ref   :interaction/id}
 
-   {:db/id               #db/id[:db.part/user]
+   {:db/id               (tempid :db.part/user)
     :pace.xref/attribute :interactor-info/antibody
     :pace.xref/obj-ref   :interaction/id}])
 

--- a/src/pseudoace/wormbase_schema_fixups.clj
+++ b/src/pseudoace/wormbase_schema_fixups.clj
@@ -1,4 +1,5 @@
-(ns pseudoace.wormbase-schema-fixups)
+(ns pseudoace.wormbase-schema-fixups
+  (:require [datomic.api :refer (tempid)]))
 
 (def schema-fixups
   [
@@ -45,39 +46,39 @@
    ;; (see https://github.com/WormBase/db/wiki/Ace-to-Datomic-mapping#xrefs-in-hash-models)
    ;;
 
-   {:db/id               #db/id[:db.part/user]
+   {:db/id               (tempid :db.part/user)
     :pace.xref/attribute :multi-counts.gene/gene
     :pace.xref/obj-ref   :multi-pt-data/id}
 
-   {:db/id               #db/id[:db.part/user]
+   {:db/id               (tempid :db.part/user)
     :pace.xref/attribute :multi-counts.allele/variation
     :pace.xref/obj-ref   :multi-pt-data/id}
 
-   {:db/id               #db/id[:db.part/user]
+   {:db/id               (tempid :db.part/user)
     :pace.xref/attribute :multi-counts.locus/locus
     :pace.xref/obj-ref   :multi-pt-data/id}
 
-   {:db/id               #db/id[:db.part/user]
+   {:db/id               (tempid :db.part/user)
     :pace.xref/attribute :multi-counts.transgene/transgene
     :pace.xref/obj-ref   :multi-pt-data/id}
 
-   {:db/id               #db/id[:db.part/user]
+   {:db/id               (tempid :db.part/user)
     :pace.xref/attribute :multi-counts.rearrangement/rearrangement
     :pace.xref/obj-ref   :multi-pt-data/id}
 
-   {:db/id               #db/id[:db.part/user]
+   {:db/id               (tempid :db.part/user)
     :pace.xref/attribute :mass-spec-data/protein
     :pace.xref/obj-ref   :mass-spec-peptide/id}
 
-   {:db/id               #db/id[:db.part/user]
+   {:db/id               (tempid :db.part/user)
     :pace.xref/attribute :interactor-info/transgene
     :pace.xref/obj-ref   :interaction/id}
 
-   {:db/id               #db/id[:db.part/user]
+   {:db/id               (tempid :db.part/user)
     :pace.xref/attribute :interactor-info/construct
     :pace.xref/obj-ref   :interaction/id}
 
-   {:db/id               #db/id[:db.part/user]
+   {:db/id               (tempid :db.part/user)
     :pace.xref/attribute :interactor-info/antibody
     :pace.xref/obj-ref   :interaction/id}
 
@@ -85,7 +86,7 @@
    ;; Timestamp
    ;;
    
-   {:db/id          #db/id[:db.part/tx]
+   {:db/id          (tempid  :db.part/tx)
     :db/txInstant   #inst "1970-01-01T00:00:01"}
 
    ])


### PR DESCRIPTION
This provides:
- `lein uberjar` now compiles and successfully produces jar files.
- Running `lein eastwood` now reports no syntax errors
- Editor warnings/errors in Emacs (using the kibit and eastwood linters) are gone.
