### PR TITLE
Do not play transactions with old timestamps.

### DIFF
--- a/src/pseudoace/core.clj
+++ b/src/pseudoace/core.clj
@@ -357,7 +357,7 @@
         (println \tab "importing: " (.getName file)))
       (ts-import/play-logfile
        con
-       (java.util.zip.GZIPInputStream. (io/input-stream file)))
+       (java.util.zip.GZIPInputStream. (io/input-stream file))))
     (d/release con)))
 
 (defn excise-tmp-data

--- a/src/pseudoace/core.clj
+++ b/src/pseudoace/core.clj
@@ -347,6 +347,8 @@
   (if verbose
     (println "Importing logs into datomic" url log-dir verbose))
   (let [con (d/connect url)
+        db (d/db con)
+        latest-tx-dt (ts-import/latest-transaction-date db)
         log-files (get-sorted-edn-log-files log-dir)]
     (if verbose
       (println "Importing" (count log-files) "log files"))
@@ -355,7 +357,7 @@
         (println \tab "importing: " (.getName file)))
       (ts-import/play-logfile
        con
-       (java.util.zip.GZIPInputStream. (io/input-stream file))))
+       (java.util.zip.GZIPInputStream. (io/input-stream file)))
     (d/release con)))
 
 (defn excise-tmp-data

--- a/src/pseudoace/ts_import.clj
+++ b/src/pseudoace/ts_import.clj
@@ -1,9 +1,11 @@
- (ns pseudoace.ts-import
+(ns pseudoace.ts-import
   (:require
+   [clj-time.core :as t]
+   [clj-time.coerce :refer (from-date)]
    [clojure.instant :refer (read-instant-date)]
    [clojure.java.io :refer (file reader writer)]
    [clojure.string :as str]
-   [datomic.api :as d :refer (db q entity touch tempid)]
+   [datomic.api :as d]
    [pseudoace.aceparser :as ace]
    [pseudoace.binning :refer (bin)]
    [pseudoace.import :refer (datomize-objval get-tags)]
@@ -165,7 +167,7 @@
         nss      (:pace/use-ns ti)
         ordered? (get nss "ordered")
         hashes   (for [ns nss]
-                   (entity (:db imp) (keyword ns "id")))] ; performance?
+                   (d/entity (:db imp) (keyword ns "id")))] ; performance?
     (reduce
      (fn [log [index lines]]
        (if (and (pos? index) single?)
@@ -310,7 +312,7 @@
                 :as xref}
                lines]]
        (let [lines (remove empty? lines) ; Ignore empty inbound XREF lines.
-             remote-class (entity (d/entity-db clent) obj-ref)]
+             remote-class (d/entity (d/entity-db clent) obj-ref)]
          (if (= (namespace obj-ref) (namespace attr))
            ;; Simple case
            (reduce
@@ -328,7 +330,7 @@
            ;; Complex case
            (let [[ns an]    (str/split (namespace attr) #"\.")
                  link-attr  (if an (keyword ns an))
-                 link-ent   (entity (d/entity-db clent) link-attr)]
+                 link-ent   (d/entity (d/entity-db clent) link-attr)]
              (if (and link-ent (= ns (namespace obj-ref)))
                (reduce-kv
                 (fn [log xo lines]
@@ -383,7 +385,7 @@
 
   Currently a somewhat-conservative impl."
   [this db imp ti nodes]
-  (if-let [current-obj (and db (entity db this))]
+  (if-let [current-obj (and db (d/entity db this))]
     (let [single? (not= (:db/cardinality ti) :db.cardinality/many)
           current ((:db/ident ti) current-obj)
           current (or (and current single? [current])
@@ -674,7 +676,7 @@
                  ;; No partition hint, so we can use this as a plain
                  ;; Lookup ref.
                  [(:db/ident ci) (:id obj)])]
-    (if-let [orig (entity db this)]
+    (if-let [orig (d/entity db this)]
       (cond
        (:delete obj)
        {nil
@@ -734,7 +736,7 @@
       (let [[k v part] ref
             lref       [k v]]
         (if v
-          (if (entity db lref)
+          (if (d/entity db lref)
             ;; turn 3-element refs into normal lookup-refs
             [(assoc datom index lref) temps]
             (if-let [tid (temps ref)]
@@ -790,7 +792,7 @@
 
 (defn play-log [con log]
   (doseq [[stamp datoms] (sort-by first log)]
-    (let [db (db con)
+    (let [db (d/db con)
           datoms (fixup-datoms db datoms)]
       @(d/transact con (conj datoms (txmeta stamp))))))
 
@@ -854,10 +856,25 @@
       (doseq [sblk (partition-by first rblk)
               :let [stamp (ffirst sblk)]]
         (let [blk (map second sblk)
-              db      (db con)
+              db      (d/db con)
               fdatoms (filter (fn [[_ _ _ v]] (not (map? v))) blk)
+              tx-meta (txmeta stamp)
               datoms  (fixup-datoms db fdatoms)]
-          (try
+          (if (t/after? (-> tx-meta :db/txInstant from-date)
+                        (latest-transaction-date db))
+            (try
               @(d/transact-async con (conj datoms (txmeta stamp)))
-          (catch Throwable t
-            (.printStackTrace t))))))))
+              (catch Throwable t
+                (.printStackTrace t)))
+            (println "Skipping transaction with past-date:" stamp)))))))
+
+(defn latest-transaction-date
+  "Returns the `date-time` of the latest transaction."
+  [db]
+  (let [bt (-> db d/basis-t d/t->tx)]
+    (-> (d/q '[:find ?t
+               :in $ ?tx
+               :where [?tx :db/txInstant ?t]]
+             db bt)
+        ffirst
+        from-date)))

--- a/src/pseudoace/ts_import.clj
+++ b/src/pseudoace/ts_import.clj
@@ -850,6 +850,17 @@
                   (+ text (count v))
                   text)))))))
 
+(defn latest-transaction-date
+  "Returns the `date-time` of the latest transaction."
+  [db]
+  (let [bt (-> db d/basis-t d/t->tx)]
+    (-> (d/q '[:find ?t
+               :in $ ?tx
+               :where [?tx :db/txInstant ?t]]
+             db bt)
+        ffirst
+        from-date)))
+
 (defn play-logfile [con logfile]
   (with-open [r (reader logfile)]
     (doseq [rblk (partition-log 100 5000 (logfile-seq r))] ;; was 1000 50000
@@ -868,13 +879,3 @@
                 (.printStackTrace t)))
             (println "Skipping transaction with past-date:" stamp)))))))
 
-(defn latest-transaction-date
-  "Returns the `date-time` of the latest transaction."
-  [db]
-  (let [bt (-> db d/basis-t d/t->tx)]
-    (-> (d/q '[:find ?t
-               :in $ ?tx
-               :where [?tx :db/txInstant ?t]]
-             db bt)
-        ffirst
-        from-date)))

--- a/src/pseudoace/utils.clj
+++ b/src/pseudoace/utils.clj
@@ -1,6 +1,9 @@
 (ns pseudoace.utils
-  (:require [clojure.java.io :refer (writer)]
-            [clojure.set :refer (union)]))
+  (:require
+   [clj-time.coerce :refer (from-date)]
+   [clojure.instant :refer (read-instant-date)]
+   [clojure.java.io :refer (writer)]
+   [clojure.set :refer (union)]))
 
 (def not-nil? (complement nil?))
 
@@ -161,3 +164,18 @@
     (apply
      merge-with-set-vals
      (map #(hash-map (keyfunc %) (set (rest %))) pairs))))
+
+(defn filter-by-date
+  "Filter `coll` by date object `dt` using predicate `pred`."
+  ([coll dt pred]
+   (filter-by-date coll dt pred #"(\d{4}-\d{2}-\d{2}).*"))
+  ([coll dt pred ts-pattern]
+   (sort
+    (filter
+     not-nil?
+     (for [item coll]
+       (if-let [matches (re-matches ts-pattern item)]
+         (let [ts-str (second matches)
+               item-dt (-> ts-str read-instant-date from-date)]
+           (if (pred item-dt dt)
+             item))))))))

--- a/test/pseudoace/test_utils.clj
+++ b/test/pseudoace/test_utils.clj
@@ -1,5 +1,8 @@
 (ns pseudoace.test-utils
   (:require
+   [clj-time.coerce :refer (from-date)]
+   [clj-time.core :refer (before? after?)]
+   [clojure.instant :refer (read-instant-date)]
    [clojure.test :refer (deftest is)]
    [pseudoace.utils :as utils]))
 
@@ -18,7 +21,7 @@
          {2 "goal" 3 "score"})))
 
 (deftest test-merge-pairs
-  (is (= (utils/merge-pairs []) nil))
+  (is (nil? (utils/merge-pairs [])))
   (is (= (utils/merge-pairs [["A" "B"]]) {"A" #{"B"}}))
   (is (= (utils/merge-pairs [["A" "B"]
                              ["C" "D"]
@@ -28,3 +31,18 @@
          {"A" #{"B" "C"}
           "C" #{"D"}
           "D" #{"A" "C"}})))
+
+(deftest test-filter-by-date
+  (let [ex-date (from-date (read-instant-date "2012-10-10"))
+        coll ["2016-01-02.foo.bar"
+              "2010-02-03.bar.foo"
+              "2005-11-21.spam.eggs"
+              "2013-04-12.badger"
+              "2011-03-04.baz.say"]]
+    (is (= (utils/filter-by-date coll ex-date before?)
+           ["2005-11-21.spam.eggs"
+            "2010-02-03.bar.foo"
+            "2011-03-04.baz.say"]))
+    (is (= (utils/filter-by-date coll ex-date after?)
+           ["2013-04-12.badger"
+            "2016-01-02.foo.bar"]))))


### PR DESCRIPTION
- Skip over files named with timestamp pattern older than the latest
  transaction.
- Also, to take account of more granular times within a single file,
  check within each file too.

Fixes #25 
