### PR TITLE
Bundle release datomic flavours

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,4 +53,6 @@
   - Various minor fixes for the command line interface.
 
 ## 0.4.5 - (un-released)
-  - Nothing changed yet.
+  - Remove hard-dependency on datomic-pro.
+    Library users will now have to choose which flavour (and version)
+    of datomic to include.

--- a/README.md
+++ b/README.md
@@ -5,26 +5,38 @@ Provides a Clojure library for use by the [Wormbase][1] project.
 Features include:
 
   * Model-driven import of ACeDB data into a [Datomic][2] database.
-    * (Dynamic generation of an isomorphic Datomic schema from an
-      annotated ACeDB models file)
+
+      * (Dynamic generation of an isomorphic Datomic schema from an
+        annotated ACeDB models file)
+
   * Conversion of ACeDB database dump files into a datomic database
+
   * Routines for parsing and dumping ACeDB "dump files".
+
   * Utility functions and macros for querying WormBase data.
+
   * A command line interface for utilities described above (via `lein run`)
 
 ## Installation
 
  * Java 1.8 (Prefer official oracle version)
 
- * [leiningen][3].
+ * [leiningen][3]
 
- * Datomic Transactor (Local)
-   * Visit https://my.datomic.com/downloads/pro
-   * Download the version of datomic-pro that matches the version
-	 specified in `project.clj`.
-   * When upgrading datomic, download the latest version and update
-     `project.clj` accordingly.
-   * Unzip the downloaded archive, and run: `bin/maven-install`
+   * You will also need to specify which flavour and version of
+     datomic you want use in your [lein peer project configuration][13].
+
+     Example:
+
+     ```clojure
+     (defproject myproject-0.1-SNAPSHOT
+        :dependencies [[com.datomic/datomic-free "0.9.5359"
+                        :exclusions [joda-time]]
+                       [wormbase/pseudoace "0.4.4"]])
+     ```
+
+ * [Install datomic][14]
+
 
 ## Development
 
@@ -42,8 +54,8 @@ Run all tests regularly, but in particular:
   * before issuing a new pull request
 
   * after checking out a feature-branch
-  
-  
+
+
 ```bash
 alias run-tests="lein with-profile dev,test do eastwood, test"
 run-tests
@@ -51,7 +63,7 @@ run-tests
 
 Other useful leiningen plugins for development include:
 
-#### kibit 
+#### kibit
 Recommends [idiomatic source code changes][10].
 
 There is editor support in Emacs. e.g: `M-x kibit-current-file`
@@ -67,11 +79,15 @@ Command line examples:
 #### bikeshed
 Reports on [subjectively bad][11] code.
 This tool checks for:
+
   1. "files ending in blank lines"
+
   2. redefined var roots in source directories"
+
   3. "whether you keep up with your docstrings"
+
   4. arguments colliding with clojure.core functions
-  
+
 Of the above, only 1. 2. and 3. are generally useful to fix,
 since 4. requires creative (short) naming that may not be intuitive
 for the reader. Use your discretion when choosing to "fix" any "violations"
@@ -105,18 +121,26 @@ The output should look like (credentials elided):
 This process re-uses the [leiningen deployment tools][12]:
 
   * Checkout the `develop` branch if not already checked-out.
+
   * Update changes entries in the CHANGES.md file
+
   * Replace "un-released" in the latest version entry with the current date.
+
   * Commit and push all changes.
+
   * Merge the `develop` branch into to `master` (via a github pull
     request or directly using git)
+
   * Checkout the `master` branch.
+
   * Run:
-	 
+
 	 `lein release`
-	 
+
   * Checkout the `develop` branch.
+
   * Merge the `master` branch back into `develop`.
+
   * Update `CHANGES.md` with the next
     version number and a "back to development" stanza, e.g:
 
@@ -165,7 +189,7 @@ The archive contains two artefacts:
 >   contained therein is *never* distributed to a public server
 >   for download, as this would violate the terms of any preparatory
 >   Congnitech Datomic license.**
- 
+
 
 ## Usage
 
@@ -277,4 +301,5 @@ platform you run it on.
 [10]: https://github.com/jonase/kibit
 [11]: https://github.com/dakrone/lein-bikeshed
 [12]: https://github.com/technomancy/leiningen/blob/master/doc/DEPLOY.md#deployment
-
+[13]: http://docs.datomic.com/integrating-peer-lib.html
+[14]: http://docs.datomic.com/getting-started.html

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,7 @@
 (defproject wormbase/pseudoace "0.4.5-SNAPSHOT"
   :dependencies [[clj-time "0.11.0"]
+                 ;; [com.datomic/datomic-pro "0.9.5359"
+                 ;;  :exclusions [joda-time]]
                  [datomic-schema "1.3.0"]
                  [org.clojure/clojure "1.8.0"]
                  [org.clojure/tools.nrepl "0.2.12"]
@@ -20,7 +22,7 @@
              ;; Uncomment to prevent missing trace (HotSpot optimisation)
              ;; "-XX:-OmitStackTraceInFastThrow"
              ]
-  :main ^:skip-aot pseudoace.core
+  :main pseudoace.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}
              :test {:resource-paths ["test/resources"]}
@@ -31,10 +33,11 @@
                              [lein-kibit "0.1.2"]
                              [lein-ns-dep-graph "0.1.0-SNAPSHOT"]]
                    :resource-paths ["test/resources"]}
-             :provided {:dependencies [[com.datomic/datomic-free "0.9.5359"
-                                        :exclusions [joda-time]]
-                                       [com.datomic/datomic-pro "0.9.5359"
-                                        :exclusions [joda-time]]]}
+             :datomic-free {:dependencies [[com.datomic/datomic-free "0.9.5359"
+                                            :exclusions [joda-time]]]
+                            :exclusions [com.datomic/datomic-pro]}
+             :datomic-pro {:dependencies [[com.datomic/datomic-pro "0.9.5359"
+                                           :exclusions [joda-time]]]}
              :mysql {:dependencies [[mysql/mysql-connector-java "6.0.2"]]}
              :postgresql {:dependencies [[org.postgresql/postgresql "9.4.1208"]]}
              :ddb {:dependencies [[com.amazonaws/aws-java-sdk-dynamodb "1.9.39"

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,5 @@
 (defproject wormbase/pseudoace "0.4.5-SNAPSHOT"
   :dependencies [[clj-time "0.11.0"]
-                 [com.datomic/datomic-pro "0.9.5359" :exclusions [joda-time]]
                  [datomic-schema "1.3.0"]
                  [org.clojure/clojure "1.8.0"]
                  [org.clojure/tools.nrepl "0.2.12"]
@@ -32,10 +31,10 @@
                              [lein-kibit "0.1.2"]
                              [lein-ns-dep-graph "0.1.0-SNAPSHOT"]]
                    :resource-paths ["test/resources"]}
-             :datomic-pro {:dependencies [[com.datomic/datomic-pro "0.9.5359"
-                                           :exclusions [joda-time]]]}
-             :datomic-free {:dependencies [[com.datomic/datomic-free "0.9.5359"
-                                           :exclusions [joda-time]]]}
+             :provided {:dependencies [[com.datomic/datomic-free "0.9.5359"
+                                        :exclusions [joda-time]]
+                                       [com.datomic/datomic-pro "0.9.5359"
+                                        :exclusions [joda-time]]]}
              :mysql {:dependencies [[mysql/mysql-connector-java "6.0.2"]]}
              :postgresql {:dependencies [[org.postgresql/postgresql "9.4.1208"]]}
              :ddb {:dependencies [[com.amazonaws/aws-java-sdk-dynamodb "1.9.39"

--- a/scripts/bundle-release.sh
+++ b/scripts/bundle-release.sh
@@ -48,25 +48,19 @@ PROJ_ROOT="$(git rev-parse --show-toplevel)"
 LOGFILE="${PROJ_ROOT}/bundle-release.log"
 RELEASE_TAG="$1"
 if [ -z "${RELEASE_TAG}" ]; then
-    echo "USAGE: $0 <RELEASE_TAG> [LEIN_PROFILE=datomic-pro]"
+    echo "USAGE: $0 <RELEASE_TAG> [LEIN_PROFILE]"
     exit 1
 fi
 
 LEIN_PROFILE="$2"
-if [ -z "${LEIN_PROFILE}" ]; then
-    LEIN_PROFILE="datomic-pro"
-fi
-
-if ! [[ "${LEIN_PROFILE}" == *"datomic-"* ]]; then
-    LEIN_PROFILE="${LEIN_PROFILE},datomic-pro"
-fi
-
 PROJ_NAME="$(proj_meta ${PROJ_ROOT} name)"
 PROJ_VERSION="$(proj_meta ${PROJ_ROOT} version)"
+
 if [ -z "$PROJ_NAME" ] || [ -z "$PROJ_VERSION" ]; then
     echo "[ ❌ ] Could not determine Clojure project name and version."
     exit 2
 fi
+
 BUILD_DIR="${PROJ_NAME}-$$"
 PROJ_FQNAME="${PROJ_NAME}-${RELEASE_TAG}"
 LOG_SORT_SCRIPT="scripts/sort-edn-log.sh"


### PR DESCRIPTION
@a8wright This addresses an existing issue with leiningen dependencies.

We need to be able to conditionally build with library with different flavours of datomic:
- Website uses datomic-pro
- Build pipeline to use datomic-free
- Allow end-users to build the WormBase database locally (as they can with ACeDB)
