### PR TITLE
Fixes for cyclic xrefs in model annotation and issues with sort script.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -65,3 +65,7 @@
 
 ## 0.4.7 - (un-released)
   - Back to development.
+  - Fix for circular xrefs for `phenotype` and
+    `phenotype_not_observed` in annotated models (#46)
+  - Bug in sort-edn-log.sh - Sort command now uses the temporary sort
+    directory.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -60,5 +60,8 @@
   - EDN log sorting script now allows parallel execution.
   - Annotated models for WS255 (including generated EDN schema)
 
-## 0.4.6 - (un-released)
+## 0.4.6 - (2016-06-15)
   - Added back missing `xbin` function in `pseudoace.binning`.
+
+## 0.4.7 - (un-released)
+  - Back to development.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -65,6 +65,8 @@
 
 ## 0.4.7 - (un-released)
   - Back to development.
+  - `2_point_data` ACeDB class renamed to two-point-data in annotated
+    models (#33).
   - Fix for circular xrefs for `phenotype` and
     `phenotype_not_observed` in annotated models (#46)
   - Bug in sort-edn-log.sh - Sort command now uses the temporary sort

--- a/models/models.wrm.annot
+++ b/models/models.wrm.annot
@@ -3507,10 +3507,10 @@
                                  In_pos_neg_data ?Pos_neg_data NOXREF xxxx
                                  // these are for when the locus is mapped
                     Marked_rearrangement ?Rearrangement INXREF By_variation
-           Description Phenotype ?Phenotype INXREF Variation #Phenotype_info
+           Description Phenotype ?Phenotype OUTXREF Variation #Phenotype_info
                        Phenotype_remark ?Text #Evidence
-                       Phenotype_not_observed ?Phenotype INXREF Not_in_Variation #Phenotype_info  //added by Wen to separate Not phenotype from real phenotypes 
-           Reference ?Paper INXREF Allele
+                       Phenotype_not_observed ?Phenotype OUTXREF Not_in_Variation #Phenotype_info  //added by Wen to separate Not phenotype from real phenotypes
+           Reference ?Paper OUTXREF Allele
            Remark ?Text #Evidence
 //           Method UNIQUE ?Method       // Becomes :locatable/method
            Supporting_data Movie ?Movie INXREF Variation #Evidence  //Carol [060421 ar2] 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject wormbase/pseudoace "0.4.6"
+(defproject wormbase/pseudoace "0.4.7-SNAPSHOT"
   :dependencies [[clj-time "0.11.0"]
                  ;; [com.datomic/datomic-pro "0.9.5359"
                  ;;  :exclusions [joda-time]]

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,5 @@
 (defproject wormbase/pseudoace "0.4.7-SNAPSHOT"
   :dependencies [[clj-time "0.11.0"]
-                 ;; [com.datomic/datomic-pro "0.9.5359"
-                 ;;  :exclusions [joda-time]]
                  [datomic-schema "1.3.0"]
                  [org.clojure/clojure "1.8.0"]
                  [org.clojure/tools.nrepl "0.2.12"]

--- a/scripts/sort-edn-log.sh
+++ b/scripts/sort-edn-log.sh
@@ -24,7 +24,7 @@ cd $log_dir
 mkdir -p "$tmp_sort_dir"
 
 gzip -dc "$log_filename" \
-    | sort -T sort-temp -k 1,1 -s \
+    | sort -T "$tmp_sort_dir" -k 1,1 -s \
     | gzip -c > "$sorted_filename"
 
 if [ $? -eq 0 ] && [ -f "$sorted_filename" ]; then


### PR DESCRIPTION
This fixes an issue with the sort script , where the temporary directory was not being used by the actual sort command (!).

Also:
- Fix (some) cyclic xref references (those reported by @azurebrd )

Other cyclic referenes remain, but should fixed in the main ACeDB models, then merged back in.
This will be done for WS256.
