### PR TITLE
Ace file dumping

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -73,3 +73,6 @@
 
 ## 0.4.8-SNAPSHOT - (un-released)
   - Fix wrong exit-code when helper.gz is encountered in `sort-edn-log.sh`.
+  - When dumping .ace files, only present the leaf tag (as the `tace`
+    `Show` command) - enables easier comparisons of ace output.
+  - Add functions for dumping a query to .ace files

--- a/src/pseudoace/acedump.clj
+++ b/src/pseudoace/acedump.clj
@@ -98,7 +98,7 @@
 
 (defn- xref-obj
   "Helper to find the object at the outbound end of an inbound XREF.
-   Returns a vector of [object attribute comp] where `comp` is the 
+   Returns a vector of [object attribute comp] where `comp` is the
    component entity which reifies this XREF, or nil for a simple XREF."
   ([db ent obj-ref]
    (xref-obj db ent nil nil obj-ref))
@@ -108,7 +108,7 @@
       [r (d/entity db a) v])
     (if-let [[e a v t] (first (d/datoms db :vaet (:db/id ent)))]
       (xref-obj db (d/entity db e) a v obj-ref)))))
-     
+
 (defn ace-object
  ([db eid]
   (ace-object db eid nil))

--- a/src/pseudoace/acedump.clj
+++ b/src/pseudoace/acedump.clj
@@ -113,10 +113,9 @@
   (ace-object db eid nil))
  ([db eid restrict-ns]
   (let [datoms        (d/datoms db :eavt eid)
-        data          (->>
-                       (partition-by :a datoms)
-                       (map (fn [d]
-                              [(d/entity db (:a (first d))) d])))
+        data          (map (fn [d]
+                             [(d/entity db (:a (first d))) d])
+                           (partition-by :a datoms))
         data          (if restrict-ns
                         (filter (fn [[a v]]
                                   (restrict-ns (namespace (:db/ident a))))
@@ -204,7 +203,9 @@
 
      ;; Positional parameters exist.
      (seq positional)
-     (loop [[[attr datoms] & rest] (reverse (sort-by (comp :pace/order first) positional))
+     (loop [[[attr datoms] & rest] (reverse
+                                    (sort-by (comp :pace/order first)
+                                             positional))
             children               (:children named-tree)]
        (let [n (assoc (value-node db attr (tsmap (:tx (first datoms))) (first datoms))
                  :children children)]

--- a/src/pseudoace/acedump.clj
+++ b/src/pseudoace/acedump.clj
@@ -32,10 +32,10 @@
 (defn smin
   "Generalized `min` which works on anything that can be `compare`d."
   [a b]
-  (if (> (compare a b) 0)
+  (if (pos? (compare a b))
     b a))
 
-(defn- squote
+(defn squote
   "ACeDB-style string quoting"
   [s]
   (str \" (str/replace s "\"" "\\\"") \"))
@@ -137,8 +137,7 @@
         named-tree    (reduce
                        (fn [root [attr datoms]]
                          (if-let [tags (:pace/tags attr)]
-                           (let [min-ts    (->> (map (comp tsmap :tx) datoms)
-                                                (reduce smin))]
+                           (let [min-ts (reduce smin (map (comp tsmap :tx) datoms))]
                              (if (= (:db/valueType attr) :db.type/boolean)
                                (if (some :v datoms)
                                  (splice-in-tagpath
@@ -176,8 +175,7 @@
                                                (map (fn [tx]
                                                       [tx (tx->ts (d/entity db tx))]))
                                                (into {}))
-                                  min-ts  (->> (map (comp tsmap :tx) datoms)
-                                               (reduce smin))]
+                                  min-ts (reduce smin (map (comp tsmap :tx) datoms))]
                               (splice-in-tagpath
                                root
                                (str/split (:pace.xref/tags xref) #"\s")

--- a/src/pseudoace/core.clj
+++ b/src/pseudoace/core.clj
@@ -13,6 +13,7 @@
    [clojure.tools.cli :refer (parse-opts)]
    [datomic.api :as d]
    [pseudoace.aceparser :as ace]
+   [pseudoace.acedump :as acedump]
    [pseudoace.import :refer (importer)]
    [pseudoace.locatable-import :as loc-import]
    [pseudoace.model :as model]

--- a/src/pseudoace/model2schema.clj
+++ b/src/pseudoace/model2schema.clj
@@ -327,8 +327,7 @@
  ([model]
   (model->schema {} model))
  ([tpm {:keys [name alt-name] :as model}]
-  (let [mns (or alt-name
-                (datomize-name name))
+  (let [mns (or alt-name (datomize-name name))
         is-hash? (.startsWith name "#")
         pid (if (not is-hash?)
               (tempid :db.part/db))

--- a/src/pseudoace/model2schema.clj
+++ b/src/pseudoace/model2schema.clj
@@ -153,12 +153,12 @@
               (not= (:type fchild) :hash)
               (not (:enum node))
               ;; Becomes complex if there's a hash at the other end of the XREF.
-              (not (if-let [x (:xref fchild)] 
+              (not (if-let [x (:xref fchild)]
                      (:use-ns (tpm [(datomize-name (:name fchild)) x])))))
        ;; "simple datum" case
        (when-not (:suppress-xref fchild)
          (let [cname       (:name fchild)
-               type        (modeltype-to-datomic  (:type fchild))
+               type        (modeltype-to-datomic (:type fchild))
                schema [(utils/vmap
                         :db/id           (tempid :db.part/db)
                         :db/ident        attribute
@@ -288,7 +288,7 @@
                                    :pace.xref/use-ns     use-ns)}))
                    schema)))
              ;; In enum case, order 0 is reserved for the enum.
-             (iterate inc (if enum 1 0)) 
+             (iterate inc (if enum 1 0))
              concretes
              (tuple-member-names concretes attribute)))
 

--- a/src/pseudoace/model2schema.clj
+++ b/src/pseudoace/model2schema.clj
@@ -127,6 +127,7 @@
        :db/cardinality      :db.cardinality/one
        :db.install/_attribute :db.part/db
        :pace/tags           (str/join " " tagpath))]
+
      ;; "simple enum" case -- the only ones we auto-detect.
      ;; Could this be merged with the other enum case?
      (every? simple-tag? (:children node))
@@ -143,9 +144,11 @@
                                :db.cardinality/many)
          :db.install/_attribute :db.part/db
          :pace/tags       (str/join " " tagpath))))
+
      (or (and (= (count (:children node)) 1)
               (#{:int :float :text :ref :date :hash} (:type fchild)))
          (:enum node))      ;; "Simple" enums have already been caught at this point.
+
      (if (and (empty? (:children fchild))
               (not= (:type fchild) :hash)
               (not (:enum node))


### PR DESCRIPTION
@a8wright The following enables easier comparison of `.ace` output from datomic.

This is towards ensuring that we have data integrity by round triipping to .ace files - a future release may contain an enhanced QA report that chooses selective objects from  the database and dumps them as `.ace` files then compare to the source ACedB database .ace output,  For now, this enables us to do so manually.
