### PR TITLE
Changed the qa report to process CSV provided build asset.

### DIFF
--- a/CHANELOG.md
+++ b/CHANELOG.md
@@ -1,7 +1,7 @@
 # Change-log
 
 ## [0.5.1] - (un-released)
-  - Nothing changed yet.
+  - QA report now uses new ACeDB id catalog csv format.
 
 ## [0.5.0] - (2017-04-27)
   - Added `distinct-by` utility function.

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,8 @@
 (defproject wormbase/pseudoace "0.5.1-SNAPSHOT"
   :dependencies [[clj-time "0.13.0"]
                  [clj-yaml "0.4.0"]
+                 [clojure-csv/clojure-csv "2.0.1"]
+                 [com.gfredericks/forty-two "1.0.0"]
                  [datomic-schema "1.3.0"]
                  [environ "1.1.0"]
                  [org.clojure/clojure "1.8.0"]

--- a/src/pseudoace/model2schema.clj
+++ b/src/pseudoace/model2schema.clj
@@ -1,6 +1,7 @@
 (ns pseudoace.model2schema
   (:require
    [clojure.string :as str]
+   [com.gfredericks.forty-two :as f2]
    [datomic.api :as d :refer [entity entity-db q tempid]]
    [pseudoace.model :refer [model-node]]
    [pseudoace.utils :as utils]))
@@ -8,15 +9,18 @@
 (def ^:dynamic *schema-notes* false)
 
 (defn datomize-name
-  "Make `n` into a Datomic-friendly name by converting to lower case and replacing
-   underscores with hyphens."
+  "Make `n` into a Datomic-friendly name by converting to lower case
+  and replacing underscores with hyphens."
   [^String n]
   (if (Character/isDigit (first n))
-    (if *schema-notes*
-      (println "WARNING: name starts with a digit: " n)))
-  (let [dn (-> (.toLowerCase n)
+    (when *schema-notes*
+      (println "WARNING: name starts with a digit: " n)
+      (println "         Assuming literal English translation, "
+               "e.g 2 -> two")))
+  (let [dn (-> (str/lower-case n)
+               (str/replace #"^\d+" (comp f2/words read-string))
                (str/replace #"[?#]" "")
-               (str/replace #"_" "-"))]
+               (str/replace #"(_|\s)" "-"))]
     (if (= dn "id")  ; id is reserved for the object name.
       "xid"
       dn)))

--- a/src/pseudoace/qa.clj
+++ b/src/pseudoace/qa.clj
@@ -63,11 +63,11 @@
 
 (defn- stats-data [report]
   (let [entries (sort-by (comp namespace :attr) (:entries report))]
-    (for [entry entries
-          :let [attr (:attr entry)
-                class-name (:class-name entry)]]
+    (for [entry entries]
       (if entry
-        (let [n-ref-only (.n-ref-only entry)
+        (let [attr (:attr entry)
+              class-name (:class-name entry)
+              n-ref-only (.n-ref-only entry)
               n-db-only (.n-db-only entry)
               n-both (.n-both entry)]
           (map str [class-name attr n-ref-only n-db-only n-both]))))))

--- a/src/pseudoace/qa.clj
+++ b/src/pseudoace/qa.clj
@@ -10,15 +10,22 @@
    [pseudoace.model2schema :refer [datomize-name]]
    [pseudoace.utils :refer [merge-pairs]]))
 
-(def ^:private report-headings
-  ["ACeDB-class" "datomic-ident" "Missing" "Added" "Identical"])
+(def ^{:private true} report-headings
+  ["ACeDB" "datomic" "Missing" "Added" "Identical"])
 
-(defn- write-append [writer record & {:keys [verbose]
-                                      :or {verbose false}}]
+(defn- write-append [writer record
+                     & {:keys [verbose]
+                        :or {verbose false}}]
   (let [s (csv/write-csv [record])]
     (when verbose
       (print s))
     (.write writer s)))
+
+(defn- merge-split-record [rec]
+  (list (first rec)
+        (->> (rest rec)
+             (str/join ",")
+             (str/trim))))
 
 (defn read-ref-data
   "Read class data generated from a WormBase ACeDB database via `reader`.
@@ -26,12 +33,12 @@
   The file contains one line per class-value pair, in the format:
      className : identifier
 
-  Returns a mapping of className to set of identifiers per map.
-  "
+  Returns a mapping of className to set of identifiers per ACeDB class."
   [acedb-report-path]
   (with-open [rdr (io/reader acedb-report-path)]
-    (if-let [records (seq (csv/parse-csv rdr))]
-      (merge-pairs records))))
+    (->> (csv/parse-csv rdr)
+         (map merge-split-record)
+         (merge-pairs))))
 
 (defrecord StatsReport [class-names entries])
 
@@ -51,41 +58,42 @@
 
 (defn- report-entry [db ref-data native->ref attr]
   (let [class-name (native->ref attr)
-        query-result (d/q '[:find ?a ?v
-                            :in $ ?a
-                            :where [_ ?a ?v]]
-                          db attr)
-        mapped (or (merge-pairs query-result) {})
-        db-values (set (mapped attr))
+        db-values (->> (d/q '[:find [?v ...]
+                              :in $ ?a
+                              :where [_ ?a ?v]]
+                            db attr)
+                       (map pr-str)
+                       set)
         ref-values (set (ref-data class-name))
         [ref-only db-only in-both] (diff ref-values db-values)]
     (->StatsReportEntry class-name attr db-only ref-only in-both)))
 
 (defn- stats-data [report]
-  (let [entries (sort-by (comp namespace :attr) (:entries report))]
+  (let [attr-ns (comp namespace :attr)
+        entries (sort-by attr-ns (:entries report))]
     (for [entry entries]
       (if entry
-        (let [attr (:attr entry)
-              class-name (:class-name entry)
+        (let [class-name (:class-name entry)
+              attr-name (attr-ns entry)
               n-ref-only (.n-ref-only entry)
               n-db-only (.n-db-only entry)
               n-both (.n-both entry)]
-          (map str [class-name attr n-ref-only n-db-only n-both]))))))
+          (map str [class-name attr-name n-ref-only n-db-only n-both]))))))
 
 (defn report-import-stats
   "Returns a seqeunence of mappings of the diff
-   between `db` and `ref-data-path`."
+   between `:db/ident` values in datomic,
+   and ACeDB class IDs found in the file pointed to by `ref-data-path`."
   [db ref-data-path out-path & {:keys [verbose]
                                 :or {verbose false}}]
-  (let [class-names (->> (get-classes db)
-                         (map (comp :pace/identifies-class #(second %)))
-                         set
-                         sort)
-        native-names (map datomize-name class-names)
-        attrs (map #(keyword % "id") native-names)
-        native->ref (zipmap attrs class-names)]
-    (let [ref-data (read-ref-data ref-data-path)
-          rep-entry (partial report-entry db ref-data native->ref)
+  (let [ref-data (read-ref-data ref-data-path)
+        native->ref (into {} (d/q '[:find ?dn ?an
+                                    :where
+                                    [?e :db/ident ?dn]
+                                    [?e :pace/identifies-class ?an]] db))
+        attrs (keys native->ref)
+        class-names (vals native->ref)]
+    (let [rep-entry (partial report-entry db ref-data native->ref)
           report (->StatsReport class-names (pmap rep-entry attrs))]
       (spit out-path "" :append false)
       (with-open [wtr (io/writer out-path :append true)]


### PR DESCRIPTION
@a8wright Fixes #64. This PR is also _required_ before I cut the release that will fix #71.

Headline for the change: 
The "acedb_id_catalog" file generated by the hinxton build process, which is used as an input to the QA 
step in the migration has been cleaned up, and it's format of this file changed from custom-text to CSV.

datomize-name behavior changed:
 (datomize-name "2_point_data")
now returns:
  "two-point-data"

Before, would have returned nil.

i.e Convention has been codified of replacing ACeDB class names
prefixed with numerics to be their English equivilent.
Given an ACeDB class "3_UTR", would now yield "three-utr" via datomize-name.