### PR TITLE
Feature/homol import

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>wormbase</groupId>
   <artifactId>pseudoace</artifactId>
-  <version>0.6.5</version>
+  <version>0.6.6</version>
   <name>pseudoace</name>
 
   <dependencies>

--- a/src/pseudoace/acedump.clj
+++ b/src/pseudoace/acedump.clj
@@ -8,7 +8,7 @@
 
 (defrecord Node [type ts value children])
 
-(def ^:private ace-date-format
+(def ace-date-format
   (tf/formatter "yyyy-MM-dd_hh:mm:ss"))
 
 (def ^{:dynamic true

--- a/src/pseudoace/cli.clj
+++ b/src/pseudoace/cli.clj
@@ -397,7 +397,7 @@
     (when verbose
       (println "Importing" (count log-files)
                "log files from" log-dir
-               " with latest-tx-dt:" latest-tx-dt))
+               "with latest-tx-dt:" latest-tx-dt))
     (doseq [file log-files]
       (when verbose
         (println \tab "importing: " (fs/name file)))
@@ -471,7 +471,6 @@
     (println \tab "Processing locatable data from: " file))
   (doseq [blk (partition-all 20 (utils/read-ace file))]
     (loc-import/split-locatables-to-dir helper-db blk log-dir)))
-
 
 (def ace-by-cls-dump-pattern #"^dump_\d{4}-\d{2}-\d{2}_A_(\w.+)\.\d+\.ace\.gz")
 

--- a/src/pseudoace/cli.clj
+++ b/src/pseudoace/cli.clj
@@ -381,12 +381,11 @@
   "Import the sorted EDN log files."
   [& {:keys
       [url log-dir partition-max-count partition-max-text no-sorted-edn no-fixup-datoms verbose]
-      :or
-      {verbose false
-       partition-max-count *partition-max-count*
-       partition-max-text *partition-max-text*
-       no-sorted-edn false
-       no-fixup-datoms false}}]
+      :or {verbose false
+           partition-max-count *partition-max-count*
+           partition-max-text *partition-max-text*
+           no-sorted-edn false
+           no-fixup-datoms false}}]
   (when verbose
     (println "Importing logs into datomic database" url "from log files in" log-dir))
   (let [conn (d/connect url)

--- a/src/pseudoace/cli.clj
+++ b/src/pseudoace/cli.clj
@@ -575,7 +575,7 @@
     nil))
 
 (defn import-locatable-refs
-  "Copy Protein and Motif identifiers into the h omology database."
+  "Copy Protein and Motif identifiers into the homology database."
   [& {:keys [url acedump-dir homol-db-name verbose]
       :or {verbose false
            homol-db-name "homol"}}]

--- a/src/pseudoace/cli.clj
+++ b/src/pseudoace/cli.clj
@@ -319,6 +319,7 @@
      (ts-import/split-logs-to-dir imp blk log-dir))))
 
 (def helper-filename "helper.edn.gz")
+
 (def helper-folder-name "helper")
 
 (defn helper-dest-file [log-dir]

--- a/src/pseudoace/cli.clj
+++ b/src/pseudoace/cli.clj
@@ -441,7 +441,7 @@
   ;; then pull out objects from the pipeline in chunks of 20 objects.
   ;; Larger block size may be faster if
   ;; you have plenty of memory.
-  (doseq [blk (partition-all 20 (patching/read-ace-patch file))]
+  (doseq [blk (partition-all 20 (utils/read-ace file))]
     (loc-import/split-locatables-to-dir helper-db blk log-dir)))
 
 (defn run-locatables-importer-for-helper

--- a/src/pseudoace/cli.clj
+++ b/src/pseudoace/cli.clj
@@ -521,6 +521,8 @@
              no-fixups
              verbose]
       :or {schema-filename nil
+           no-locatable-schema false
+           no-fixups false
            verbose false}}]
   (create-database :url url
                    :models-filename models-filename

--- a/src/pseudoace/locatable_import.clj
+++ b/src/pseudoace/locatable_import.clj
@@ -1,9 +1,9 @@
 (ns pseudoace.locatable-import
-  (:require [datomic.api :as d :refer (q entity touch tempid)]
-            [pseudoace.binning :refer (bin)]
-            [pseudoace.ts-import :as ts-imp]
-            [pseudoace.utils :as utils]
-            ))
+  (:require
+   [datomic.api :as d]
+   [pseudoace.binning :as binning]
+   [pseudoace.ts-import :as ts-imp]
+   [pseudoace.utils :as utils]))
 
 ;;
 ;; TODO:
@@ -13,25 +13,23 @@
 
 (defn- bin-me-maybe [this [attr id] min max]
   (if (= attr :sequence/id)
-    [:db/add this :locatable/murmur-bin (bin id min max)]))
+    [:db/add this :locatable/murmur-bin (binning/bin id min max)]))
 
 (defn- log-features [feature-lines parent offset]
   (let [offset (or offset 0)]
     (reduce
      (fn [log [[method start-s end-s score note :as core] [lines]]]
-       (let [tid   [:importer/temp (str (d/squuid))]
+       (let [tid [:importer/temp (str (d/squuid))]
              start (utils/parse-int start-s)
-             end   (utils/parse-int end-s)
-             min   (+ offset -1 (min start end))
-             max   (+ offset (max start end))]
+             end (utils/parse-int end-s)
+             min (+ offset -1 (min start end))
+             max (+ offset (max start end))]
          (update log (second (:timestamps (meta core)))
                  utils/conj-if
                  [:db/add tid :locatable/parent parent]
                  [:db/add tid :locatable/min min]
                  [:db/add tid :locatable/max max]
-                 [:db/add tid :locatable/strand (if (> start end)
-                                                  :locatable.strand/negative
-                                                  :locatable.strand/positive)]
+                 [:db/add tid :locatable/strand (utils/strand start end)]
                  [:db/add tid :locatable/method [:method/id method]]
                  (if score
                    [:db/add tid :locatable/score (utils/parse-double score)])
@@ -41,6 +39,7 @@
      {}
      (group-by (partial ts-imp/take-ts 5) feature-lines))))
 
+;; Matt/TODO:: decactivate
 (defn- log-splice-confirmations [splice-lines parent offset]
   (let [offset (or offset 0)]
     (reduce
@@ -59,30 +58,28 @@
                        [:db/add tid :locatable/parent parent]
                        [:db/add tid :locatable/min min]
                        [:db/add tid :locatable/max max]
-                       [:db/add tid :locatable/strand (if (> start end)
-                                                        :locatable.strand/negative
-                                                   :locatable.strand/positive)]
+                       [:db/add tid :locatable/strand (utils/strand start end)]
                        (bin-me-maybe tid parent min max))
-                      
+
                       (case confirm-type
                         "cDNA"
                         [[:db/add tid :splice-confirm/cdna [:sequence/id confirm]]]
-                        
+
                         "EST"
                         [[:db/add tid :splice-confirm/est [:sequence/id confirm]]]
-                        
+
                         "OST"
                         [[:db/add tid :splice-confirm/ost [:sequence/id confirm]]]
-                        
+
                         "RST"
                         [[:db/add tid :splice-confirm/rst [:sequence/id confirm]]]
-                        
+
                         "RNASeq"
                         (let [rtid [:importer/temp (str (d/squuid))]]
                           [[:db/add tid :splice-confirm/rnaseq rtid]
                            [:db/add rtid :splice-confirm.rnaseq/analysis [:analysis/id confirm]]
                            [:db/add rtid :splice-confirm.rnaseq/count (utils/parse-int confirm-x)]])
-                        
+
                         "Mass_spec"
                         [[:db/add tid :splice-confirm/mass-spec [:mass-spec-peptide/id confirm]]]
 
@@ -108,74 +105,68 @@
 ;; this probably needs revisiting if we use this code for things other than ?Protein homols
 ;;
 
+(defmulti homol-tx-data (fn [ace-tag tx-data tid target protein?]
+                          ace-tag))
+
+(defmethod homol-tx-data "Pep_homol" [_ tx-data tid target _]
+  (conj tx-data [:db/add tid :homology/protein [:protein/id target]]))
+
+(defmethod homol-tx-data "Motif_homol" [_ tx-data tid target _]
+  (conj tx-data [:db/add tid :homology/motif [:motif/id target]]))
+
+(defmethod homol-tx-data "DNA_homol" [_ tx-data tid target protein?]
+  (if protein?
+    (utils/throw-exc "Don't support protein->DNA homols")
+    (conj tx-data [:db/add tid :homology/dna [:sequence/id target]])))
+
+;; Other possible homol tags to dispatch on are (at time of writing):
+;; - Structure_homol
+;; - RNAi_homol
+;; - Oligo_set_homol
+;; - Expr_homol
+;; - MSPeptide_homol
+;; - SAGE_homol
+;; - Homol_homol
+;; In thomas's original implementation, Homol_homol was silently ignored, the rest generated tx-data.
+;; Here we are only chosing to process Pep_homol and Motif_homol as these are the ones needed by the website.
+;; Including the rest may lead to excessive database size (for not gain as the data is not used)
+
+(defmethod homol-tx-data :default [_ _ _ _ _]
+  nil)
+
 (defn- log-homols [homol-lines parent offset protein?]
- (let [offset (or offset 0)]
-  (reduce
-   (fn [log [[type target method score-s parent-start-s parent-end-s target-start-s target-end-s :as line] lines ]] 
-     (let [tid   [:importer/temp (str (d/squuid))]
-           start (utils/parse-int parent-start-s)
-           end   (utils/parse-int parent-end-s)
-           min   (if start (+ offset -1 start))
-           max   (if end (+ offset end))]
-           (update log (first (drop 3 (:timestamps (meta line))))
-             (fn [old]
-               (into (or old [])
-                (let [base (utils/those
-                             [:db/add tid :locatable/parent parent]
-                             (and (some? method) [:db/add tid :locatable/method [:method/id method]])
-                             (and (some? min) [:db/add tid :locatable/min min])
-                             (and (some? max) [:db/add tid :locatable/max max])
-                             (and (not-any? nil? [start end]) (if-not protein?
-                               [:db/add tid :locatable/strand (if (> start end)
-                                                                :locatable.strand/negative
-                                                                :locatable.strand/positive)]))
-                             (and (not-any? nil? [min max]) (bin-me-maybe tid parent min max))
-                             (and (some? target-start-s) [:db/add tid :homology/min (dec (utils/parse-int target-start-s))])
-                             (and (some? target-end-s) [:db/add tid :homology/max      (utils/parse-int target-end-s)   ])
-                             (and (some? score-s) [:db/add tid :locatable/score (utils/parse-double score-s)]))]
-                   (case type
-                     "DNA_homol"
-                     (if protein?
-                       (utils/throw-exc "Don't support protein->DNA homols")
-                       (conj base [:db/add tid :homology/dna [:sequence/id target]]))
-    
-                     "Pep_homol"
-                     (conj base [:db/add tid :homology/protein [:protein/id target]])
-                     
-                     "Structure_homol"
-                     (conj base [:db/add tid :homology/structure [:structure-data/id target]])
-    
-                     "Motif_homol"
-                     (conj base [:db/add tid :homology/motif [:motif/id target]])
-    
-                     "RNAi_homol"
-                     (conj base [:db/add tid :homology/rnai [:rnai/id target]])
-    
-                     "Oligo_set_homol"
-                     (conj base [:db/add tid :homology/oligo-set [:oligo-set/id target]])
-    
-                     "Expr_homol"
-                     (conj base [:db/add tid :homology/expr [:expr-pattern/id target]])
-    
-                     "MSPeptide_homol"
-                     (conj base [:db/add tid :homology/ms-peptide [:mass-spec-peptide/id target]])
-    
-                     "SAGE_homol"
-                     (conj base [:db/add tid :homology/sage [:sage-tag/id target]])
-    
-                     "Homol_homol"   ;; silently ignore
-                     nil
-    
-                     ;; default
-                     (utils/throw-exc "Don't understand homology type " type))))))))
-       {}
-   (group-by (partial ts-imp/take-ts 8) homol-lines))))
-              
+  (let [offset (or offset 0)]
+    (reduce
+     (fn [log [[type target method score-s parent-start-s parent-end-s target-start-s target-end-s :as line] lines]]
+       (let [tid [:importer/temp (str (d/squuid))]
+             start (utils/parse-int parent-start-s)
+             end (utils/parse-int parent-end-s)
+             min (if start (+ offset -1 start))
+             max (if end (+ offset end))]
+         (update log (first (drop 3 (:timestamps (meta line))))
+                 (fn [old]
+                   (into (or old [])
+                         (let [base (utils/those
+                                     [:db/add tid :locatable/parent parent]
+                                     (and (some? method) [:db/add tid :locatable/method [:method/id method]])
+                                     (and (some? min) [:db/add tid :locatable/min min])
+                                     (and (some? max) [:db/add tid :locatable/max max])
+                                     (and (not-any? nil? [start end]) (if-not protein?
+                                                                        [:db/add tid :locatable/strand (utils/strand start end)]))
+                                     (and (not-any? nil? [min max]) (bin-me-maybe tid parent min max))
+                                     (and (some? target-start-s) [:db/add tid :homology/min (dec (utils/parse-int target-start-s))])
+                                     (and (some? target-end-s) [:db/add tid :homology/max (utils/parse-int target-end-s)])
+                                     (and (some? score-s) [:db/add tid :locatable/score (utils/parse-double score-s)]))]
+                           (if-let [data (homol-tx-data type base tid target protein?)]
+                             data
+                             (utils/throw-exc "Don't understand homology type " type))))))))
+     {}
+     (group-by (partial ts-imp/take-ts 8) homol-lines))))
 
 (defmulti log-locatables (fn [_ obj] (:class obj)))
 
 (defmethod log-locatables "Feature_data" [db obj]
-  (if-let [fd (entity db [:feature-data/id (:id obj)])]
+  (if-let [fd (d/entity db [:feature-data/id (:id obj)])]
    (let [parent [:sequence/id (:sequence/id (:locatable/parent fd))]]
     (if (= (:locatable/strand fd)
            :locatable.strand/negative)
@@ -200,11 +191,11 @@
      (log-homols   (ts-imp/select-ts obj ["Homol"])   parent nil true))))
 
 (defmethod log-locatables "Homol_data" [db obj]
-  (if-let [homol (entity db [:homol-data/id (:id obj)])]
+  (if-let [homol (d/entity db [:homol-data/id (:id obj)])]
    (let [parent [:sequence/id (:sequence/id (:locatable/parent homol))]]
     (if (= (:locatable/strand homol)
            :locatable.strand/negative)
-      (println "Skipping" (:id obj) "because negative strand")      
+      (println "Skipping" (:id obj) "because negative strand")
       (log-homols
        (ts-imp/select-ts obj ["Homol"])
        parent

--- a/src/pseudoace/locatable_import.clj
+++ b/src/pseudoace/locatable_import.clj
@@ -36,7 +36,7 @@
 ;; - Structure_homol
 ;; - RNAi_homol
 ;; - Oligo_set_homol
-xo;; - Expr_homol
+;; - Expr_homol
 ;; - MSPeptide_homol
 ;; - SAGE_homol
 ;; - Homol_homol

--- a/src/pseudoace/locatable_import.clj
+++ b/src/pseudoace/locatable_import.clj
@@ -1,5 +1,7 @@
 (ns pseudoace.locatable-import
   (:require
+   [clojure.set :as set]
+   [clojure.string :as str]
    [datomic.api :as d]
    [pseudoace.binning :as binning]
    [pseudoace.ts-import :as ts-imp]
@@ -15,199 +17,98 @@
   (if (= attr :sequence/id)
     [:db/add this :locatable/murmur-bin (binning/bin id min max)]))
 
-(defn- log-features [feature-lines parent offset]
-  (let [offset (or offset 0)]
-    (reduce
-     (fn [log [[method start-s end-s score note :as core] [lines]]]
-       (let [tid [:importer/temp (str (d/squuid))]
-             start (utils/parse-int start-s)
-             end (utils/parse-int end-s)
-             min (+ offset -1 (min start end))
-             max (+ offset (max start end))]
-         (update log (second (:timestamps (meta core)))
-                 utils/conj-if
-                 [:db/add tid :locatable/parent parent]
-                 [:db/add tid :locatable/min min]
-                 [:db/add tid :locatable/max max]
-                 [:db/add tid :locatable/strand (utils/strand start end)]
-                 [:db/add tid :locatable/method [:method/id method]]
-                 (if score
-                   [:db/add tid :locatable/score (utils/parse-double score)])
-                 (if note
-                   [:db/add tid :locatable/note note])
-                 (bin-me-maybe tid parent min max))))
-     {}
-     (group-by (partial ts-imp/take-ts 5) feature-lines))))
-
-;; Matt/TODO:: decactivate
-(defn- log-splice-confirmations [splice-lines parent offset]
-  (let [offset (or offset 0)]
-    (reduce
-     (fn [log [start-s end-s confirm-type confirm confirm-x :as line]]
-       (if confirm
-         (let [tid   [:importer/temp (str (d/squuid))]
-               start (utils/parse-int start-s)
-               end   (utils/parse-int end-s)
-               min   (+ offset -1 (min start end))
-               max   (+ offset (max start end))]
-           (update log (first (drop 2 (:timestamps (meta line))))
-             (fn [old]
-               (into (or old [])
-                     (concat
-                      (utils/those
-                       [:db/add tid :locatable/parent parent]
-                       [:db/add tid :locatable/min min]
-                       [:db/add tid :locatable/max max]
-                       [:db/add tid :locatable/strand (utils/strand start end)]
-                       (bin-me-maybe tid parent min max))
-
-                      (case confirm-type
-                        "cDNA"
-                        [[:db/add tid :splice-confirm/cdna [:sequence/id confirm]]]
-
-                        "EST"
-                        [[:db/add tid :splice-confirm/est [:sequence/id confirm]]]
-
-                        "OST"
-                        [[:db/add tid :splice-confirm/ost [:sequence/id confirm]]]
-
-                        "RST"
-                        [[:db/add tid :splice-confirm/rst [:sequence/id confirm]]]
-
-                        "RNASeq"
-                        (let [rtid [:importer/temp (str (d/squuid))]]
-                          [[:db/add tid :splice-confirm/rnaseq rtid]
-                           [:db/add rtid :splice-confirm.rnaseq/analysis [:analysis/id confirm]]
-                           [:db/add rtid :splice-confirm.rnaseq/count (utils/parse-int confirm-x)]])
-
-                        "Mass_spec"
-                        [[:db/add tid :splice-confirm/mass-spec [:mass-spec-peptide/id confirm]]]
-
-                        "Homology"
-                        [[:db/add tid :splice-confirm/homology confirm]]
-
-                        "UTR"
-                        [[:db/add tid :splice-confirm/utr [:sequence/id confirm]]]
-
-                        "False"
-                        [[:db/add tid :splice-confirm/false-splice [:sequence/id confirm]]]
-
-                        "Inconsistent"
-                        [[:db/add tid :splice-confirm/inconsistent [:sequence/id confirm]]]))))))
-         log))   ;; There are a certain number of these with missing data, which we'll skip.
-     {}
-     splice-lines)))
-
-;;
+;
 ;; For version 1, we're *not* going to try collapsing Homol lines into single gapped alignments,
 ;; since it seems that the blastp importer is only recording one line per sub-hit...
 ;;
 ;; this probably needs revisiting if we use this code for things other than ?Protein homols
 ;;
 
-(defmulti homol-tx-data (fn [ace-tag tx-data tid target protein?]
-                          ace-tag))
-
-(defmethod homol-tx-data "Pep_homol" [_ tx-data tid target _]
-  (conj tx-data [:db/add tid :homology/protein [:protein/id target]]))
-
-(defmethod homol-tx-data "Motif_homol" [_ tx-data tid target _]
-  (conj tx-data [:db/add tid :homology/motif [:motif/id target]]))
-
-(defmethod homol-tx-data "DNA_homol" [_ tx-data tid target protein?]
-  (if protein?
-    (utils/throw-exc "Don't support protein->DNA homols")
-    (conj tx-data [:db/add tid :homology/dna [:sequence/id target]])))
-
-;; Other possible homol tags to dispatch on are (at time of writing):
-;; - Structure_homol
-;; - RNAi_homol
-;; - Oligo_set_homol
-;; - Expr_homol
-;; - MSPeptide_homol
-;; - SAGE_homol
-;; - Homol_homol
 ;; In thomas's original implementation, Homol_homol was silently ignored, the rest generated tx-data.
 ;; Here we are only chosing to process Pep_homol and Motif_homol as these are the ones needed by the website.
 ;; Including the rest may lead to excessive database size (for not gain as the data is not used)
+(defn conj-into-tx-data
+  [db tx-data tid attr value]
+  (conj tx-data [:db/add tid attr value]))
 
-(defmethod homol-tx-data :default [_ _ _ _ _]
+;; Dispatch methods on ACe tag.
+;; possible homol tags to dispatch on are (at time of writing):
+;; - Structure_homol
+;; - RNAi_homol
+;; - Oligo_set_homol
+xo;; - Expr_homol
+;; - MSPeptide_homol
+;; - SAGE_homol
+;; - Homol_homol
+(defmulti homol-tx-data (fn [db tag tx-data tid value protein?]
+                          tag))
+
+(defmethod homol-tx-data "Pep_homol" [db _ tx-data tid value _]
+  (conj-into-tx-data db tx-data tid :homology/protein [:protein/id value]))
+
+(defmethod homol-tx-data "Motif_homol" [db _ tx-data tid value _]
+  (conj-into-tx-data db tx-data tid :homology/motif [:motif/id value]))
+
+(defmethod homol-tx-data "DNA_homol" [db _ tx-data tid value protein?]
+  (if protein?
+    (utils/throw-exc "Don't support protein->DNA homols")
+    (conj-into-tx-data db tx-data tid :homology/dna [:dna/id value])))
+
+(defmethod homol-tx-data :default [_ _ _ _ _ _]
   nil)
 
-(defn- log-homols [homol-lines parent offset protein?]
+(defn- log-homols [db homol-lines parent offset protein?]
   (let [offset (or offset 0)]
     (reduce
-     (fn [log [[type target method score-s parent-start-s parent-end-s target-start-s target-end-s :as line] lines]]
-       (let [tid [:importer/temp (str (d/squuid))]
+     (fn update-homol [log [[tag
+                             target
+                             method
+                             score-s
+                             parent-start-s
+                             parent-end-s
+                             target-start-s
+                             target-end-s :as line] lines]]
+       (let [tid (str (d/squuid))
              start (utils/parse-int parent-start-s)
              end (utils/parse-int parent-end-s)
-             min (if start (+ offset -1 start))
-             max (if end (+ offset end))]
-         (update log (first (drop 3 (:timestamps (meta line))))
+             min (when start
+                   (+ offset -1 start))
+             max (when end
+                   (+ offset end))]
+         (update log "homology"
                  (fn [old]
                    (into (or old [])
                          (let [base (utils/those
                                      [:db/add tid :locatable/parent parent]
-                                     (and (some? method) [:db/add tid :locatable/method [:method/id method]])
-                                     (and (some? min) [:db/add tid :locatable/min min])
-                                     (and (some? max) [:db/add tid :locatable/max max])
-                                     (and (not-any? nil? [start end]) (if-not protein?
-                                                                        [:db/add tid :locatable/strand (utils/strand start end)]))
-                                     (and (not-any? nil? [min max]) (bin-me-maybe tid parent min max))
-                                     (and (some? target-start-s) [:db/add tid :homology/min (dec (utils/parse-int target-start-s))])
-                                     (and (some? target-end-s) [:db/add tid :homology/max (utils/parse-int target-end-s)])
-                                     (and (some? score-s) [:db/add tid :locatable/score (utils/parse-double score-s)]))]
-                           (if-let [data (homol-tx-data type base tid target protein?)]
-                             data
-                             (utils/throw-exc "Don't understand homology type " type))))))))
+                                     (when (some? method)
+                                       [:db/add tid :locatable/method [:method/id method]])
+                                     (when (some? min)
+                                       [:db/add tid :locatable/min min])
+                                     (when (some? max)
+                                       [:db/add tid :locatable/max max])
+                                     (when (not-any? nil? [start end])
+                                       (if-not protein?
+                                         [:db/add tid :locatable/strand (utils/strand start end)]))
+                                     (when (not-any? nil? [min max])
+                                       (bin-me-maybe tid parent min max))
+                                     (when (some? target-start-s)
+                                       [:db/add
+                                        tid
+                                        :homology/min
+                                        (dec (utils/parse-int target-start-s))])
+                                     (when (some? target-end-s)
+                                       [:db/add tid :homology/max (utils/parse-int target-end-s)])
+                                     (when (some? score-s)
+                                       [:db/add tid :locatable/score (utils/parse-double score-s)]))]
+                           (homol-tx-data db tag base tid target protein?))))))))
      {}
-     (group-by (partial ts-imp/take-ts 8) homol-lines))))
+     (group-by (partial ts-imp/take-ts 8) homol-lines)))
 
 (defmulti log-locatables (fn [_ obj] (:class obj)))
 
-(defmethod log-locatables "Feature_data" [db obj]
-  (if-let [fd (d/entity db [:feature-data/id (:id obj)])]
-   (let [parent [:sequence/id (:sequence/id (:locatable/parent fd))]]
-    (if (= (:locatable/strand fd)
-           :locatable.strand/negative)
-      (println "Skipping" (:id obj) "because negative strand")
-      (ts-imp/merge-logs
-       (log-features
-        (ts-imp/select-ts obj ["Feature"])
-        parent
-        (:locatable/min fd))
-       (log-splice-confirmations
-        (ts-imp/select-ts obj ["Splices" "Confirmed_intron"])
-        parent
-        (:locatable/min fd))
-       ;; Predicted_5 and Predicted_3 don't seem to be used
-       )))
-    (println "Couldn't find ?Feature_data " (:id obj))))
-
 (defmethod log-locatables "Protein" [db obj]
   (let [parent [:protein/id (:id obj)]]
-    (ts-imp/merge-logs
-     (log-features (ts-imp/select-ts obj ["Feature"]) parent nil)
-     (log-homols   (ts-imp/select-ts obj ["Homol"])   parent nil true))))
-
-(defmethod log-locatables "Homol_data" [db obj]
-  (if-let [homol (d/entity db [:homol-data/id (:id obj)])]
-   (let [parent [:sequence/id (:sequence/id (:locatable/parent homol))]]
-    (if (= (:locatable/strand homol)
-           :locatable.strand/negative)
-      (println "Skipping" (:id obj) "because negative strand")
-      (log-homols
-       (ts-imp/select-ts obj ["Homol"])
-       parent
-       (:locatable/min homol)
-       false)))))
-
-(defmethod log-locatables "Sequence" [db obj]
-  (let [parent [:sequence/id (:id obj)]]
-    (log-splice-confirmations
-     (ts-imp/select-ts obj ["Splices" "Confirmed_intron"])
-     parent
-     nil)))
+    (log-homols db (ts-imp/select-ts obj ["Homol"]) parent nil true)))
 
 (defmethod log-locatables :default [_ _]
   nil)
@@ -217,4 +118,5 @@
 
 (defn split-locatables-to-dir
   [db objs dir]
-  (ts-imp/logs-to-dir (lobjs->log db objs) dir))
+  (let [logs (lobjs->log db objs)]
+    (ts-imp/logs-to-dir logs dir)))

--- a/src/pseudoace/locatable_import.clj
+++ b/src/pseudoace/locatable_import.clj
@@ -100,9 +100,9 @@
                                        [:db/add tid :homology/max (utils/parse-int target-end-s)])
                                      (when (some? score-s)
                                        [:db/add tid :locatable/score (utils/parse-double score-s)]))]
-                           (homol-tx-data db tag base tid target protein?))))))))
+                           (homol-tx-data db tag base tid target protein?)))))))
      {}
-     (group-by (partial ts-imp/take-ts 8) homol-lines)))
+     (group-by (partial ts-imp/take-ts 8) homol-lines))))
 
 (defmulti log-locatables (fn [_ obj] (:class obj)))
 

--- a/src/pseudoace/patching.clj
+++ b/src/pseudoace/patching.clj
@@ -21,16 +21,6 @@
 (def list-ace-files (filter #(or (= (fs/ext %) "ace")
                                  (str/ends-with? % ".ace.gz"))))
 
-(defn read-ace-patch
-  "Read an ACe file, uncompressing via gunzip if neccessary."
-  [filename]
-  (cond-> filename
-    (str/ends-with? filename ".ace.gz") (utils/gunzip)
-    :always
-    (-> (io/input-stream)
-        (ace/ace-reader)
-        (ace/ace-seq))))
-
 (defn santise-lookup-ref [datom]
   (let [op (first datom)]
     (cond
@@ -46,7 +36,7 @@
 
 (defn ace-patch-to-edn [imp db patch-file]
   (try
-    (->> (read-ace-patch patch-file)
+    (->> (utils/read-ace patch-file)
          (ts-import/patches->log imp db)
          (mapcat val)
          (map santise-lookup-ref)

--- a/src/pseudoace/ts_import.clj
+++ b/src/pseudoace/ts_import.clj
@@ -793,16 +793,13 @@
     `[:db/add [:importer/temp tmpid part] ...]`."
   [db datoms]
   (->> (reduce
-        (fn [{:keys [done temps] :as last-d} datom]
-          (let [eid (second datom)]
-            (if (and (vector? eid) (= (count eid) 3))
-              (if-let [[datom temps ex1] (temp-datom db datom temps 1)]
-                (if-let [[datom temps ex2] (temp-datom db datom temps 3)]
-                  {:done  (conj-if done datom ex1 ex2)
-                   :temps temps}
-                  last-d)
-                last-d)
-              {:done [datom] :temps {}})))
+        (fn [{:keys [done temps] :as last} datom]
+          (if-let [[datom temps ex1] (temp-datom db datom temps 1)]
+            (if-let [[datom temps ex2] (temp-datom db datom temps 3)]
+              {:done  (conj-if done datom ex1 ex2)
+               :temps temps}
+              last)
+            last))
         {:done [] :temps {}}
         (mapcat
          (fn [[op e a v :as datom]]

--- a/src/pseudoace/ts_import.clj
+++ b/src/pseudoace/ts_import.clj
@@ -2,10 +2,12 @@
   (:require
    [clj-time.coerce :refer [from-date to-date]]
    [clj-time.core :as ctc]
+   [clj-time.format :as ctf]
    [clojure.instant :refer [read-instant-date]]
    [clojure.java.io :as io]
    [clojure.string :as str]
    [datomic.api :as d]
+   [pseudoace.acedump :refer [ace-date-format]]
    [pseudoace.aceparser :as ace]
    [pseudoace.binning :refer [bin]]
    [pseudoace.import :refer [datomize-objval get-tags]]
@@ -15,6 +17,7 @@
                             indexed
                             parse-double
                             parse-int
+                            strand
                             vmap]])
   (:import
    (java.io FileInputStream FileOutputStream)
@@ -50,6 +53,9 @@
 (def pmatch @#'ace/pmatch)
 
 (def assign-alloc-re #"__(ALLOCATE|ASSIGN)__(.+)?")
+
+(defn format-ace-date [date]
+  (ctf/unparse ace-date-format date))
 
 (defn- imp-tmp-ident [db alloc-name obj ex-msg]
   (if alloc-name
@@ -568,9 +574,7 @@
             [:db/add child :locatable/assembly-parent this]
             [:db/add child :locatable/min (dec start)]
             [:db/add child :locatable/max end]
-            [:db/add child
-             :locatable/murmur-bin
-             (bin (second this) (dec start) end)]))))
+            [:db/add child :locatable/murmur-bin (bin (second this) (dec start) end)]))))
      {}
      subseqs)))
 
@@ -620,12 +624,8 @@
             [:db/add child :locatable/parent this]
             [:db/add child :locatable/min (dec (min start end))]
             [:db/add child :locatable/max (max start end)]
-            [:db/add child
-             :locatable/strand
-             (if (<= start end)
-               :locatable.strand/positive
-               :locatable.strand/negative)]
-            (if (= (first this) :sequence/id)
+            [:db/add child :locatable/strand (strand start end)]
+            (when (= (first this) :sequence/id)
               [:db/add child
                :locatable/murmur-bin
                (bin (second this)
@@ -827,18 +827,23 @@
 (def log-fixups
   {nil (constantly "1977-01-01_01:01:01_nil")
    "original" (constantly "1970-01-02_01:01:01_original")
-   "patch" (partial ctc/now)})
+   "patch" (constantly (str (format-ace-date (ctc/now)) "patch"))
+   "homoology" (constantly (str (format-ace-date (ctc/now)) "_homoology_import"))})
 
 (defn clean-log-keys [log]
   (into {} (for [[k v] log]
              [(if-let [f (log-fixups k)]
-                (f) k)
+                (f)
+                k)
               v])))
 
 (defn logs-to-dir
   [logs dir]
   (doseq [[stamp logs] (clean-log-keys logs)
           :let [[_ date time name] (re-matches timestamp-pattern stamp)]]
+    ;; filename is date whatever is in 1st column of "edn" file.
+    ;; when it's helper.edn.gz, cli.clj moves this to the "helper" sub folder of `dir`
+    ;; after conversion.
     (with-open [w (-> (io/file dir (str (or date stamp) ".edn.gz"))
                       (FileOutputStream. true)
                       (GZIPOutputStream.)
@@ -892,9 +897,14 @@
         ffirst
         from-date)))
 
+(defn- ms->s [n]
+  (when n
+    (/ 1000 n)))
+
 (defn play-logfile
-  [con logfile max-count max-text & {:keys [use-with?]
-                                     :or {use-with? false}}]
+  [con logfile max-count max-text & {:keys [use-with? fixup-datoms?]
+                                     :or {use-with? false
+                                          fixup-datoms? true}}]
   (with-open [r (io/reader logfile)]
     (doseq [rblk (partition-log max-count max-text (logfile-seq r))]
       (doseq [sblk (partition-by first rblk)]
@@ -902,18 +912,32 @@
               blk (map second sblk)
               db (d/db con)
               fdatoms (filter (fn [[_ _ _ v]] (not (map? v))) blk)
+              datoms (if fixup-datoms?
+                       (fixup-datoms db fdatoms)
+                       fdatoms)
               tx-meta (txmeta stamp)
-              datoms (fixup-datoms db fdatoms)
-              ms->s #(/ 1000 %)
-              imp-tx-secs (ms->s (-> tx-meta :db/txInstant (.getTime)))
-              last-db-tx-secs (ms->s (-> db
-                                         latest-transaction-date
-                                         to-date
-                                         (.getTime)))]
-          (if (<= imp-tx-secs last-db-tx-secs)
-            (let [transact (if use-with?
-                             (partial d/with db)
-                             (fn [txes]
-                               @(d/transact-async con txes)))]
-              (transact (conj datoms tx-meta)))
-            (println "Skipping transaction with past-date:" stamp)))))))
+              imp-tx-secs (ms->s (some-> tx-meta :db/txInstant (.getTime)))
+              last-db-tx-secs (ms->s (some-> db
+                                             latest-transaction-date
+                                             to-date
+                                             (.getTime)))
+              has-timestamp? (number? stamp)]
+          (when has-timestamp?
+            (when (< imp-tx-secs last-db-tx-secs)
+              (println "Skipping transaction with past-date:" stamp)))
+          (let [has-tx-meta? (seq (dissoc tx-meta :db/id))
+                transact (if use-with?
+                           (partial d/with db)
+                           (fn [txes]
+                             @(d/transact-async con txes)))]
+            (let [tx-data (if has-tx-meta?
+                            (conj datoms tx-meta)
+                            datoms)]
+              (try
+                (transact tx-data)
+                (catch Exception ex
+                  (throw (ex-info (.getMessage ex)
+                                  {:orig-exception ex
+                                   :tx-data tx-data})))))))))))
+
+

--- a/src/pseudoace/ts_import.clj
+++ b/src/pseudoace/ts_import.clj
@@ -828,7 +828,7 @@
   {nil (constantly "1977-01-01_01:01:01_nil")
    "original" (constantly "1970-01-02_01:01:01_original")
    "patch" (constantly (str (format-ace-date (ctc/now)) "patch"))
-   "homoology" (constantly (str (format-ace-date (ctc/now)) "_homoology_import"))})
+   "homology" (constantly (str (format-ace-date (ctc/now)) "_homology_import"))})
 
 (defn clean-log-keys [log]
   (into {} (for [[k v] log]

--- a/src/pseudoace/utils.clj
+++ b/src/pseudoace/utils.clj
@@ -5,7 +5,8 @@
    [clojure.set :refer [union]]
    [clojure.java.io :as io]
    [clojure.string :as str]
-   [clojure.walk :as walk])
+   [clojure.walk :as walk]
+   [pseudoace.aceparser :as ace])
   (:import
    (java.util Properties)
    (java.io FileInputStream)
@@ -238,6 +239,21 @@
        str
        (FileInputStream.)
        (GZIPInputStream.)))
+
+(defn read-ace
+  "Read an ACe file, uncompressing via gunzip if neccessary."
+  [filename]
+  (cond-> filename
+    (str/ends-with? filename ".ace.gz") (gunzip)
+    :always
+    (-> (io/input-stream)
+        (ace/ace-reader)
+        (ace/ace-seq))))
+
+(defn strand [start end]
+  (if (<= start end)
+    :locatable.strand/positive
+    :locatable.strand/negative))
 
 (load "utils_wbdb")
 

--- a/test/pseudoace/cli_test.clj
+++ b/test/pseudoace/cli_test.clj
@@ -1,4 +1,4 @@
-(ns pseudoace.test-cli
+(ns pseudoace.cli-test
   (:require
    [clojure.java.io :as io]
    [clojure.test :refer (deftest is)]

--- a/test/pseudoace/qa_test.clj
+++ b/test/pseudoace/qa_test.clj
@@ -1,4 +1,4 @@
-(ns pseudoace.test-qa
+(ns pseudoace.qa-test
   (:require
    [clojure.java.io :as io]
    [clojure.test :refer (deftest is)]

--- a/test/pseudoace/schemata_test.clj
+++ b/test/pseudoace/schemata_test.clj
@@ -1,4 +1,4 @@
-(ns pseudoace.test-schemata
+(ns pseudoace.schemata-test
   (:require
    [clj-time.coerce :refer [to-date]]
    [clojure.java.io :as io]

--- a/test/pseudoace/transcripts_test.clj
+++ b/test/pseudoace/transcripts_test.clj
@@ -1,4 +1,4 @@
-(ns pseudoace.test-transcripts
+(ns pseudoace.transcripts-test
   (:require
    [clojure.test :as t]
    [cognitect.transcriptor :as xr]))

--- a/test/pseudoace/utils_test.clj
+++ b/test/pseudoace/utils_test.clj
@@ -1,4 +1,4 @@
-(ns pseudoace.test-utils
+(ns pseudoace.utils-test
   (:require
    [clj-time.coerce :refer (from-date)]
    [clj-time.core :refer (before? after?)]

--- a/test/pseudoace/utils_wbdb_test.clj
+++ b/test/pseudoace/utils_wbdb_test.clj
@@ -1,4 +1,4 @@
-(ns pseudoace.test-utils-wbdb
+(ns pseudoace.utils-wbdb-test
   (:require
    [clojure.java.io :as io]
    [clojure.test :refer :all]


### PR DESCRIPTION
Implements #81 
(_No rush to merge this - prefer we test the db first; can make any amendments to this PR_)

Converts homology from ACeDB to a seperate database, for Motif and Protein classes only.
This is accomplished by creating "stub" entities for all motif and protein objects in the new database,
then converting the motif and homology "locatable" entities associated with each, using a variation of the original's code in `locatable_import.clj`.

This requires adding 5 new commands to the migration process (but they could be run in parallel or at any time that the source ACeDB database is made available)

By default, this new datomic database is stored in the same DynamoDB table.  

Below is some examples of using the new database.

```clojure
(d/q '[:find (count ?e) .
             :where [?e :homology/protein _]] db)
```

```text
-> 17697895
```

```clojure
(d/q '[:find (count ?e) .
             :where [?e :homology/motif _]] db)
```

```text
-> 1894084
```

```clojure
;; Example query of homology db:
(d/q '[:find ?pid ?method ?min ?max ?score
             :in $hdb ?pid
             :where 
             [$hdb ?e :protein/id ?pid]
             [$hdb ? :homology/protein ?e]
             [$hdb ?lp :locatable/parent ?e]
             [$hdb ?lp :locatable/method ?mid]
             [$hdb ?mid :method/id ?method]
             [$hdb ?lp :locatable/max ?min]
             [$hdb ?lp :locatable/max ?max]
             [$hdb ?lp :locatable/score ?score]]
           hdb
           "RP01893")
;; ... results in:
#{["RP01893" "wublastp_human" 146 146 62.09691] ["RP01893" "wublastp_slimSwissProt" 149 149 65.39794] ["RP01893" "wublastp_fly" 152 152 71.69897] ["RP01893" "hmmpanther" 151 151 254.4] ["RP01893" "wublastp_brugia" 73 73 17.0] ["RP01893" "wublastp_slimSwissProt" 149 149 64.0] ["RP01893" "wublastp_slimSwissProt" 151 151 63.39794] ["RP01893" "wublastp_pristionchus" 149 149 82.52288] ["RP01893" "wublastp_ovolvulus" 142 142 67.09691] ["RP01893" "wublastp_remanei" 153 153 105.2218] ["RP01893" "pfam" 151 151 195.5] ["RP01893" "wublastp_brugia" 83 83 20.0] ["RP01893" "wublastp_brugia" 151 151 54.39794] ["RP01893" "wublastp_human" 131 131 58.69897] ["RP01893" "wublastp_human" 149 149 68.30103] ["RP01893" "wublastp_slimSwissProt" 150 150 61.69897] ["RP01893" "wublastp_brugia" 153 153 72.52288] ["RP01893" "wublastp_yeast" 150 150 61.04576] ["RP01893" "superfamily" 149 149 0.0] ["RP01893" "interpro" 151 151 0.0] ["RP01893" "wublastp_slimSwissProt" 152 152 64.04576] ["RP01893" "wublastp_yeast" 150 150 61.1549] ["RP01893" "wublastp_briggsae" 153 153 96.69897] ["RP01893" "wublastp_human" 131 131 62.30103] ["RP01893" "wublastp_slimSwissProt" 151 151 65.09691] ["RP01893" "wublastp_tmuris" 153 153 71.69897] ["RP01893" "wublastp_human" 150 150 72.0] ["RP01893" "wublastp_slimSwissProt" 149 149 60.69897] ["RP01893" "wublastp_slimSwissProt" 149 149 63.52288] ["RP01893" "wublastp_japonica" 150 150 96.52288] ["RP01893" "interpro" 150 150 0.0] ["RP01893" "wublastp_sratti" 149 149 81.30103] ["RP01893" "wublastp_worm" 153 153 105.1549] ["RP01893" "tigrfam" 150 150 224.4] ["RP01893" "wublastp_slimSwissProt" 150 150 71.39794]}

;; Query across both main and homol dbs gives same result,
;; but verifies that protein/id exists in both (join om string id)
(d/q '[:find ?pid ?method ?min ?max ?score
             :in $mdb $hdb ?pid
             :where 
             [$mdb ?ae :protein/id ?pid]
             [$hdb ?e :protein/id ?pid]
             [$hdb ? :homology/protein ?e]
             [$hdb ?lp :locatable/parent ?e]
             [$hdb ?lp :locatable/method ?mid]
             [$hdb ?mid :method/id ?method]
             [$hdb ?lp :locatable/max ?min]
             [$hdb ?lp :locatable/max ?max]
             [$hdb ?lp :locatable/score ?score]]
           mdb hdb
           "RP01893")		
```